### PR TITLE
Add info to the README about mesa 25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vulkan Wayland HDR WSI Layer
 
+_NOTE: This hack is not needed as of mesa 25.1, if used with Proton GE. See their [release page](https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton10-2) for more info._
+
 Implements the following vulkan extensions, if either frog-color-management-v1 or xx-color-management-v4 Wayland protocol is supported by the compositor:
 - [VK_EXT_swapchain_colorspace](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_swapchain_colorspace.html)
 - [VK_EXT_hdr_metadata](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_hdr_metadata.html)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Vulkan Wayland HDR WSI Layer
 
-_NOTE: This hack is not needed as of mesa 25.1, if used with Proton GE. See their [release page](https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton10-2) for more info._
-
+_NOTE: Mesa 25.1+ implements the color management protocol directly, this Vulkan layer is no longer necessary with that.
 Implements the following vulkan extensions, if either frog-color-management-v1 or xx-color-management-v4 Wayland protocol is supported by the compositor:
 - [VK_EXT_swapchain_colorspace](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_swapchain_colorspace.html)
 - [VK_EXT_hdr_metadata](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_hdr_metadata.html)


### PR DESCRIPTION
I am not super knowledgeable about this subject, but it looks to me like using Proton GE with Mesa>=25.1 is preferred over this hack. Creating this PR to maximize visibility for folks hunting for HDR on Linux and make their lives a little easier.

From [GE Proton 10-2 release](https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton10-2):
> Removes setting ENABLE_HDR_WSI -- this option is only specific for the vk_hdr_layer (https://github.com/Zamundaaa/VK_hdr_layer) hack, which is -not- needed as of mesa 25.1 and can cause washed out colors. If you previously used this, it's advised to remove it, and update mesa to 25.1 if you want HDR.